### PR TITLE
Fix: align network name with docs (use 'metapocket_net' instead of 'm…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     restart: unless-stopped
     #network
     networks:
-      metabase_net:
+      metapocket_net:
         ipv4_address: 192.168.2.150
     dns:
       - 192.168.2.2
@@ -32,7 +32,7 @@ services:
     restart: unless-stopped
     #network
     networks:
-      metabase_net:
+      metapocket_net:
         ipv4_address: 192.168.2.151
     dns:
       - 192.168.2.2
@@ -49,5 +49,5 @@ volumes:
     driver: local
 
 networks:
-  metabase_net:
+  metapocket_net:
     external: true


### PR DESCRIPTION
This PR updates the docker-compose.yml file to use the correct network name metapocket_net, as suggested in the project's documentation.

Changes:

- Replaced metabase_net with metapocket_net in both services and the network declaration.
- Ensures static IP assignment remains consistent with the specified subnet.
- This avoids runtime errors and improves consistency between the documentation and the actual Compose configuration.